### PR TITLE
[#62] Replace `BigDecimal` with `Temperature` type alias in temperature-related fields and constants (zenflow)

### DIFF
--- a/src/main/kotlin/org/agrfesta/sh/api/providers/switchbot/SwitchBotModel.kt
+++ b/src/main/kotlin/org/agrfesta/sh/api/providers/switchbot/SwitchBotModel.kt
@@ -8,7 +8,7 @@ import org.agrfesta.sh.api.domain.devices.DeviceFeature
 import org.agrfesta.sh.api.domain.devices.DeviceFeature.SENSOR
 import org.agrfesta.sh.api.domain.devices.SensorReadings
 import org.agrfesta.sh.api.domain.devices.ThermoHygroDataValue
-import java.math.BigDecimal
+import org.agrfesta.sh.api.domain.commons.Temperature
 
 enum class SwitchBotDeviceType(val features: Set<DeviceFeature>) {
     @JsonProperty("MeterPlus") METER_PLUS(setOf(SENSOR)),
@@ -18,7 +18,7 @@ enum class SwitchBotDeviceType(val features: Set<DeviceFeature>) {
 }
 
 data class SwitchBotSensorReadings(
-    val temperature: BigDecimal,
+    val temperature: Temperature,
     val humidityInt: Int,
     val batteryLevel: Int
 ) {

--- a/src/main/kotlin/org/agrfesta/sh/api/providers/switchbot/devices/SwitchBotMeter.kt
+++ b/src/main/kotlin/org/agrfesta/sh/api/providers/switchbot/devices/SwitchBotMeter.kt
@@ -3,8 +3,8 @@ package org.agrfesta.sh.api.providers.switchbot.devices
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
-import java.math.BigDecimal
 import java.util.*
+import org.agrfesta.sh.api.domain.commons.temperatureOf
 import org.agrfesta.sh.api.domain.devices.FailureByException
 import org.agrfesta.sh.api.domain.devices.Provider
 import org.agrfesta.sh.api.domain.devices.Sensor
@@ -24,7 +24,7 @@ class SwitchBotMeter (
         try{
             val jsonNode = client.getDeviceStatus(deviceProviderId)
             SwitchBotSensorReadings(
-                temperature = jsonNode.at("/body/temperature").asText().let { BigDecimal(it) },
+                temperature = jsonNode.at("/body/temperature").asText().let { temperatureOf(it) },
                 humidityInt = jsonNode.at("/body/humidity").intValue(),
                 batteryLevel = jsonNode.at("/body/battery").intValue())
                 .toSensorReadings()

--- a/src/main/kotlin/org/agrfesta/sh/api/schedulers/HeatingControlScheduler.kt
+++ b/src/main/kotlin/org/agrfesta/sh/api/schedulers/HeatingControlScheduler.kt
@@ -2,6 +2,7 @@ package org.agrfesta.sh.api.schedulers
 
 import java.math.BigDecimal
 import kotlinx.coroutines.runBlocking
+import org.agrfesta.sh.api.domain.commons.Temperature
 import org.agrfesta.sh.api.domain.areas.HeatableArea
 import org.agrfesta.sh.api.domain.devices.Heater
 import org.agrfesta.sh.api.domain.failures.PersistenceFailure
@@ -35,7 +36,7 @@ class HeatingControlScheduler(
         /**
          * The global temperature hysteresis (1.0 degree) used to prevent rapid toggling of heaters.
          */
-        val HYSTERESIS: BigDecimal = BigDecimal.ONE
+        val HYSTERESIS: Temperature = BigDecimal.ONE
         const val HEATING_ENABLED_KEY = "heating.enabled"
     }
 


### PR DESCRIPTION
## Context / Description

The codebase defines `Temperature` as a typealias for `BigDecimal` in `DataTypes.kt`:

```kotlin
typealias Temperature = BigDecimal
```

Several fields and constants that semantically represent temperature values are still typed as raw `BigDecimal`, missing the domain expressiveness that the `Temperature` alias provides. Using `Temperature` instead of `BigDecimal` improves code readability, makes intent explicit, and keeps the domain model consistent.

This change is **low-risk** because `Temperature` is a typealias — no runtime behaviour changes.

---

## Affected Locations

### 1. `HeatingControlScheduler.HYSTERESIS` — constant used in temperature arithmetic

**File**: `src/main/kotlin/org/agrfesta/sh/api/schedulers/HeatingControlScheduler.kt`

```kotlin
// Current
val HYSTERESIS: BigDecimal = BigDecimal.ONE

// Expected
val HYSTERESIS: Temperature = BigDecimal.ONE
```

`HYSTERESIS` is used directly in temperature arithmetic (`targetTemp.plus(HYSTERESIS)`, `targetTemp.minus(HYSTERESIS)`) in `SharedHeatingAreasStrategyService` and `EconomyAreasSharedHeatingStrategyService`. It semantically represents a temperature delta of 1 degree.

---

### 2. `SwitchBotSensorReadings.temperature` — sensor reading DTO field

**File**: `src/main/kotlin/org/agrfesta/sh/api/providers/switchbot/SwitchBotModel.kt`

```kotlin
// Current
data class SwitchBotSensorReadings(
    val temperature: BigDecimal,
    ...
)

// Expected
data class SwitchBotSensorReadings(
    val temperature: Temperature,
    ...
)
```

This field holds a temperature reading from the SwitchBot API and is passed directly to `ThermoHygroData(temperature = temperature, ...)`, which already expects `Temperature`.

---

### 3. `SwitchBotMeter.fetchReadings()` — temperature parsing

**File**: `src/main/kotlin/org/agrfesta/sh/api/providers/switchbot/devices/SwitchBotMeter.kt`

```kotlin
// Current
temperature = jsonNode.at("/body/temperature").asText().let { BigDecimal(it) }

// Expected
temperature = jsonNode.at("/body/temperature").asText().let { temperatureOf(it) }
```

Using the domain constructor `temperatureOf(it)` is consistent with how other temperature values are created in the codebase.

---

## Acceptance Criteria

- [ ] `HeatingControlScheduler.HYSTERESIS` is declared as `Temperature` instead of `BigDecimal`.
- [ ] `SwitchBotSensorReadings.temperature` field is typed as `Temperature` instead of `BigDecimal`.
- [ ] `SwitchBotMeter.fetchReadings()` uses `temperatureOf(it)` instead of `BigDecimal(it)` for the temperature field.
- [ ] All existing tests continue to pass after the changes.
- [ ] No new `BigDecimal` usages are introduced for fields that semantically represent temperatures.

## Out of Scope

The following `BigDecimal` usages are **intentionally excluded** from this issue:

- `SensorHistoryData.value: BigDecimal` — generic sensor value (can be temperature or humidity); a potential future refactoring into sealed types is a separate task.
- `AbsoluteHumidity` internal mathematical constants (`a`, `b`, `c`, `conversionFactor`, `shiftForKelvin`) — physical constants in the Magnus formula, not domain temperature values.
- `BigDecimal` usages in percentage ratio calculations inside `EconomyAreasSharedHeatingStrategyService` — these produce `Percentage`, not `Temperature`.