### PR TITLE
[#64] Percentage model refactoring (zenflow)

### DIFF
--- a/src/main/kotlin/org/agrfesta/sh/api/domain/commons/AbsoluteHumidity.kt
+++ b/src/main/kotlin/org/agrfesta/sh/api/domain/commons/AbsoluteHumidity.kt
@@ -4,7 +4,7 @@ import java.math.BigDecimal
 import java.math.MathContext
 import java.math.RoundingMode
 
-class AbsoluteHumidity(temperature: Temperature, relativeHumidity: RelativeHumidityHundreds) {
+class AbsoluteHumidity(temperature: Temperature, relativeHumidity: Percentage) {
     val value: BigDecimal
 
     companion object {
@@ -29,7 +29,7 @@ class AbsoluteHumidity(temperature: Temperature, relativeHumidity: RelativeHumid
 
         // Calculate absolute humidity (AH)
         val absoluteHumidity = saturationVaporPressure
-            .multiply(relativeHumidity.value)
+            .multiply(relativeHumidity.value.movePointRight(2))
             .multiply(conversionFactor)
             .divide(temperatureKelvin, mc)
 

--- a/src/main/kotlin/org/agrfesta/sh/api/domain/commons/DataTypes.kt
+++ b/src/main/kotlin/org/agrfesta/sh/api/domain/commons/DataTypes.kt
@@ -5,7 +5,6 @@ import java.math.RoundingMode
 
 typealias Temperature = BigDecimal
 typealias RelativeHumidity = Percentage
-typealias RelativeHumidityHundreds = PercentageHundreds
 
 fun Collection<Temperature>.average(): Temperature? {
     if (isEmpty()) return null

--- a/src/main/kotlin/org/agrfesta/sh/api/domain/commons/Percentage.kt
+++ b/src/main/kotlin/org/agrfesta/sh/api/domain/commons/Percentage.kt
@@ -4,38 +4,24 @@ import java.math.BigDecimal
 import java.math.BigDecimal.ONE
 import java.math.BigDecimal.ZERO
 
-data class Percentage(val value: BigDecimal) {
-    constructor(percentage: String): this(BigDecimal(percentage))
-
+@JvmInline
+value class Percentage(val value: BigDecimal) {
     init {
         require(value >= ZERO && value <= ONE) { "Percentage must be between 0 and 1, is $value." }
     }
 
     fun asText(): String = value.toString()
-    fun toHundreds(): PercentageHundreds {
+
+    override fun toString(): String {
         var hundreds = value.movePointRight(2)
-        if (hundreds.scale() > 0) {
-            hundreds = hundreds.stripTrailingZeros()
-        }
-        return PercentageHundreds(hundreds)
+        if (hundreds.scale() > 0) hundreds = hundreds.stripTrailingZeros()
+        return "$hundreds%"
     }
-
-    override fun toString(): String = toHundreds().toString()
-}
-
-data class PercentageHundreds(val value: BigDecimal) {
-    constructor(hundredPercentage: String): this(BigDecimal(hundredPercentage))
-    constructor(hundredPercentage: Int): this(BigDecimal(hundredPercentage))
 
     companion object {
-        private val HUNDRED = BigDecimal(100)
+        fun of(percentage: String) = Percentage(BigDecimal(percentage))
+        fun ofHundreds(value: BigDecimal) = Percentage(value.movePointLeft(2).stripTrailingZeros())
+        fun ofHundreds(value: Int) = ofHundreds(BigDecimal(value))
+        fun ofHundreds(value: String) = ofHundreds(BigDecimal(value))
     }
-
-    init {
-        require(value >= ZERO && value <= HUNDRED) { "Percentage hundreds must be between 0 and 100, is $value." }
-    }
-
-    fun toPercentage() = Percentage(value.movePointLeft(2).stripTrailingZeros())
-
-    override fun toString(): String = "$value%"
 }

--- a/src/main/kotlin/org/agrfesta/sh/api/domain/commons/Percentage.kt
+++ b/src/main/kotlin/org/agrfesta/sh/api/domain/commons/Percentage.kt
@@ -17,8 +17,12 @@ value class Percentage(val value: BigDecimal) {
     }
 
     companion object {
+        private val HUNDRED = BigDecimal(100)
         fun of(percentage: String) = Percentage(BigDecimal(percentage))
-        fun ofHundreds(value: BigDecimal) = Percentage(value.movePointLeft(2).stripTrailingZeros())
+        fun ofHundreds(value: BigDecimal): Percentage {
+            require(value >= ZERO && value <= HUNDRED) { "Percentage hundreds must be between 0 and 100, is $value." }
+            return Percentage(value.movePointLeft(2).stripTrailingZeros())
+        }
         fun ofHundreds(value: Int) = ofHundreds(BigDecimal(value))
         fun ofHundreds(value: String) = ofHundreds(BigDecimal(value))
     }

--- a/src/main/kotlin/org/agrfesta/sh/api/domain/commons/Percentage.kt
+++ b/src/main/kotlin/org/agrfesta/sh/api/domain/commons/Percentage.kt
@@ -10,8 +10,6 @@ value class Percentage(val value: BigDecimal) {
         require(value >= ZERO && value <= ONE) { "Percentage must be between 0 and 1, is $value." }
     }
 
-    fun asText(): String = value.toString()
-
     override fun toString(): String {
         var hundreds = value.movePointRight(2)
         if (hundreds.scale() > 0) hundreds = hundreds.stripTrailingZeros()

--- a/src/main/kotlin/org/agrfesta/sh/api/domain/commons/ThermoHygroData.kt
+++ b/src/main/kotlin/org/agrfesta/sh/api/domain/commons/ThermoHygroData.kt
@@ -4,5 +4,5 @@ data class ThermoHygroData(
     val temperature: Temperature,
     val relativeHumidity: RelativeHumidity
 ) {
-    fun calculateAbsoluteHumidity() = AbsoluteHumidity(temperature, relativeHumidity.toHundreds())
+    fun calculateAbsoluteHumidity() = AbsoluteHumidity(temperature, relativeHumidity)
 }

--- a/src/main/kotlin/org/agrfesta/sh/api/providers/netatmo/NetatmoModel.kt
+++ b/src/main/kotlin/org/agrfesta/sh/api/providers/netatmo/NetatmoModel.kt
@@ -1,8 +1,9 @@
 package org.agrfesta.sh.api.providers.netatmo
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.math.BigDecimal
 import java.time.Instant
-import org.agrfesta.sh.api.domain.commons.RelativeHumidityHundreds
+import org.agrfesta.sh.api.domain.commons.Percentage
 import org.agrfesta.sh.api.domain.commons.Temperature
 import org.agrfesta.sh.api.domain.commons.ThermoHygroData
 import org.agrfesta.sh.api.domain.devices.ThermoHygroDataValue
@@ -36,7 +37,7 @@ data class NetatmoStatusChangeRequest(
 
 data class NetatmoRoomStatus(
     val id: String,
-    val humidity: RelativeHumidityHundreds,
+    val humidity: BigDecimal,
     @JsonProperty("open_window") val openWindow: Boolean,
     @JsonProperty("therm_measured_temperature") val measuredTemperature: Temperature,
     @JsonProperty("therm_setpoint_temperature") val setPointTemperature: Temperature,
@@ -46,7 +47,7 @@ data class NetatmoRoomStatus(
 ): ThermoHygroDataValue {
     override val thermoHygroData = ThermoHygroData(
         temperature = measuredTemperature,
-        relativeHumidity = humidity.toPercentage()
+        relativeHumidity = Percentage.ofHundreds(humidity)
     )
 }
 

--- a/src/main/kotlin/org/agrfesta/sh/api/providers/switchbot/SwitchBotModel.kt
+++ b/src/main/kotlin/org/agrfesta/sh/api/providers/switchbot/SwitchBotModel.kt
@@ -1,7 +1,7 @@
 package org.agrfesta.sh.api.providers.switchbot
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import org.agrfesta.sh.api.domain.commons.PercentageHundreds
+import org.agrfesta.sh.api.domain.commons.Percentage
 import org.agrfesta.sh.api.domain.commons.ThermoHygroData
 import org.agrfesta.sh.api.domain.devices.BatteryValue
 import org.agrfesta.sh.api.domain.devices.DeviceFeature
@@ -26,7 +26,7 @@ data class SwitchBotSensorReadings(
     fun toSensorReadings(): SensorReadings = object : ThermoHygroDataValue, BatteryValue {
         override val thermoHygroData = ThermoHygroData(
             temperature = temperature,
-            relativeHumidity = PercentageHundreds(humidityInt).toPercentage()
+            relativeHumidity = Percentage.ofHundreds(humidityInt)
         )
         override val battery: Int = batteryLevel
     }

--- a/src/main/kotlin/org/agrfesta/sh/api/services/heating/EconomyAreasSharedHeatingStrategyService.kt
+++ b/src/main/kotlin/org/agrfesta/sh/api/services/heating/EconomyAreasSharedHeatingStrategyService.kt
@@ -27,8 +27,9 @@ import org.springframework.stereotype.Service
  */
 @Service
 class EconomyAreasSharedHeatingStrategyService(
-    @param:Value("\${heating.params.economy-areas-percentage:0.5}") private val percentage: Percentage
+    @Value("\${heating.params.economy-areas-percentage:0.5}") percentageValue: BigDecimal
 ): NamedSharedHeatingAreasStrategyService, AbstractSharedHeatingAreasStrategyService() {
+    private val percentage = Percentage(percentageValue)
     private val logger by LoggerDelegate()
     override val strategy: SharedHeatingAreasStrategy = SharedHeatingAreasStrategy.ECONOMY
 
@@ -54,12 +55,12 @@ class EconomyAreasSharedHeatingStrategyService(
         val neededHeatingPerc = Percentage(BigDecimal(areasToHeat.size)
             .divide(BigDecimal(areas.size), 2, RoundingMode.HALF_UP))
         if (neededHeatingPerc.value >= percentage.value) {
-            logger.info("${neededHeatingPerc.toHundreds()} of the heatable areas require heating. " +
-                    "(above ${percentage.toHundreds()}) -> heater ON")
+            logger.info("$neededHeatingPerc of the heatable areas require heating. " +
+                    "(above $percentage) -> heater ON")
             sharedHeater.on()
         } else {
-            logger.info("${neededHeatingPerc.toHundreds()} of the heatable areas require heating. " +
-                    "(below ${percentage.toHundreds()}) -> heater OFF")
+            logger.info("$neededHeatingPerc of the heatable areas require heating. " +
+                    "(below $percentage) -> heater OFF")
             sharedHeater.off()
         }
     }

--- a/src/main/kotlin/org/agrfesta/sh/api/utils/SmartCache.kt
+++ b/src/main/kotlin/org/agrfesta/sh/api/utils/SmartCache.kt
@@ -5,6 +5,7 @@ import arrow.core.flatMap
 import arrow.core.left
 import arrow.core.right
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.agrfesta.sh.api.domain.commons.Percentage
 import org.agrfesta.sh.api.domain.commons.RelativeHumidity
 import org.agrfesta.sh.api.domain.commons.Temperature
 import org.agrfesta.sh.api.domain.commons.ThermoHygroData
@@ -57,7 +58,7 @@ class SmartCache(
 
     private fun ThermoHygroCacheEntry.toThermoHygroData() = ThermoHygroData(
         temperature = Temperature(t),
-        relativeHumidity = RelativeHumidity(h)
+        relativeHumidity = Percentage.of(h)
     )
 }
 

--- a/src/test/kotlin/org/agrfesta/sh/api/domain/commons/AbsoluteHumidityTest.kt
+++ b/src/test/kotlin/org/agrfesta/sh/api/domain/commons/AbsoluteHumidityTest.kt
@@ -9,13 +9,13 @@ class AbsoluteHumidityTest {
 
     @TestFactory
     fun validPercentageValues() = listOf(
-            Triple(Temperature("7.33"), RelativeHumidityHundreds("23.33"), BigDecimal("1.84668")),
-            Triple(Temperature("40.0"), RelativeHumidityHundreds("100.0"), BigDecimal("51.18221")),
-            Triple(Temperature("34.9"), RelativeHumidityHundreds("75.9"), BigDecimal("29.90525")),
-            Triple(Temperature("10.0"), RelativeHumidityHundreds("50.0"), BigDecimal("4.69675")),
-            Triple(Temperature("30.5"), RelativeHumidityHundreds("0.1"), BigDecimal("0.03119")),
-            Triple(Temperature("18.1"), RelativeHumidityHundreds("99.0"), BigDecimal("15.29155")),
-            Triple(Temperature("0.0"), RelativeHumidityHundreds("100.0"), BigDecimal("4.84977"))
+            Triple(Temperature("7.33"), Percentage.ofHundreds("23.33"), BigDecimal("1.84668")),
+            Triple(Temperature("40.0"), Percentage.ofHundreds("100.0"), BigDecimal("51.18221")),
+            Triple(Temperature("34.9"), Percentage.ofHundreds("75.9"), BigDecimal("29.90525")),
+            Triple(Temperature("10.0"), Percentage.ofHundreds("50.0"), BigDecimal("4.69675")),
+            Triple(Temperature("30.5"), Percentage.ofHundreds("0.1"), BigDecimal("0.03119")),
+            Triple(Temperature("18.1"), Percentage.ofHundreds("99.0"), BigDecimal("15.29155")),
+            Triple(Temperature("0.0"), Percentage.ofHundreds("100.0"), BigDecimal("4.84977"))
         ).map {
             dynamicTest("Temp ${it.first}°C, ${it.second} -> ${it.third}g/m³") {
                 AbsoluteHumidity(it.first, it.second).value shouldBe it.third

--- a/src/test/kotlin/org/agrfesta/sh/api/domain/commons/PercentageTest.kt
+++ b/src/test/kotlin/org/agrfesta/sh/api/domain/commons/PercentageTest.kt
@@ -26,19 +26,6 @@ class PercentageTest {
             }
 
     @TestFactory
-    fun percentageAsText() = listOf(
-        Percentage(BigDecimal.ZERO) to "0",
-        Percentage(BigDecimal("0.33333")) to "0.33333",
-        Percentage(BigDecimal("0.512")) to "0.512",
-        Percentage(BigDecimal("0.99")) to "0.99",
-        Percentage(BigDecimal.ONE) to "1"
-    ).map { (percentage, text) ->
-        dynamicTest("$percentage -> $text") {
-            percentage.asText() shouldBe text
-        }
-    }
-
-    @TestFactory
     fun percentageToString() = listOf(
         Percentage(BigDecimal.ZERO) to "0%",
         Percentage(BigDecimal("0.33333")) to "33.333%",

--- a/src/test/kotlin/org/agrfesta/sh/api/domain/commons/PercentageTest.kt
+++ b/src/test/kotlin/org/agrfesta/sh/api/domain/commons/PercentageTest.kt
@@ -26,19 +26,6 @@ class PercentageTest {
             }
 
     @TestFactory
-    fun percentageToHundredsConversions() = listOf(
-        Percentage(BigDecimal.ZERO) to PercentageHundreds(BigDecimal.ZERO),
-        Percentage(BigDecimal("0.33333")) to PercentageHundreds(BigDecimal("33.333")),
-        Percentage(BigDecimal("0.512")) to PercentageHundreds(BigDecimal("51.2")),
-        Percentage(BigDecimal("0.99")) to PercentageHundreds(BigDecimal("99")),
-        Percentage(BigDecimal.ONE) to PercentageHundreds(BigDecimal(100.0))
-    ).map { (percentage, expectedHundreds) ->
-        dynamicTest("$percentage -> $expectedHundreds") {
-            percentage.toHundreds() shouldBe expectedHundreds
-        }
-    }
-
-    @TestFactory
     fun percentageAsText() = listOf(
         Percentage(BigDecimal.ZERO) to "0",
         Percentage(BigDecimal("0.33333")) to "0.33333",
@@ -65,45 +52,48 @@ class PercentageTest {
     }
 
     @TestFactory
-    fun validPercentageHundredsValues() =
-        listOf(BigDecimal(0.0), BigDecimal(25.5), BigDecimal(59.0), BigDecimal("70.333"), BigDecimal(100.0))
-            .map {
-                dynamicTest("Percentage Hundreds from $it") { PercentageHundreds(it).value shouldBe it }
-            }
-
-    @TestFactory
-    fun invalidPercentageHundredsValues() =
-        listOf(BigDecimal(-0.000000001), BigDecimal(100.00000001), BigDecimal(150), BigDecimal(-50.1))
-            .map {
-                dynamicTest("$it is an invalid percentage hundreds value") {
-                    shouldThrow<IllegalArgumentException> { PercentageHundreds(it) }
-                        .apply { message shouldBe "Percentage hundreds must be between 0 and 100, is $it." }
-                }
-            }
-
-    @TestFactory
-    fun hundredsToPercentageConversions() = listOf(
-        PercentageHundreds(BigDecimal.ZERO) to Percentage(BigDecimal.ZERO),
-        PercentageHundreds(BigDecimal("0.333")) to Percentage(BigDecimal("0.00333")),
-        PercentageHundreds(BigDecimal("1.2")) to Percentage(BigDecimal("0.012")),
-        PercentageHundreds(BigDecimal("77")) to Percentage(BigDecimal("0.77")),
-        PercentageHundreds(BigDecimal(100.0)) to Percentage(BigDecimal.ONE)
-    ).map { (hundreds, expectedPercentage) ->
-        dynamicTest("$hundreds -> $expectedPercentage") {
-            hundreds.toPercentage() shouldBe expectedPercentage
+    fun ofHundredsFromBigDecimal() = listOf(
+        BigDecimal.ZERO to Percentage(BigDecimal.ZERO),
+        BigDecimal("0.333") to Percentage(BigDecimal("0.00333")),
+        BigDecimal("1.2") to Percentage(BigDecimal("0.012")),
+        BigDecimal("77") to Percentage(BigDecimal("0.77")),
+        BigDecimal(100.0) to Percentage(BigDecimal.ONE)
+    ).map { (hundreds, expected) ->
+        dynamicTest("ofHundreds($hundreds) -> $expected") {
+            Percentage.ofHundreds(hundreds) shouldBe expected
         }
     }
 
     @TestFactory
-    fun hundredsToString() = listOf(
-        PercentageHundreds(BigDecimal.ZERO) to "0%",
-        PercentageHundreds(BigDecimal("33.333")) to "33.333%",
-        PercentageHundreds(BigDecimal("1.2")) to "1.2%",
-        PercentageHundreds(BigDecimal("77")) to "77%",
-        PercentageHundreds(100) to "100%"
-    ).map { (hundreds, text) ->
-        dynamicTest("$hundreds -> $text") {
-            hundreds.toString() shouldBe text
+    fun ofHundredsFromInt() = listOf(
+        0 to Percentage(BigDecimal.ZERO),
+        50 to Percentage(BigDecimal("0.5")),
+        100 to Percentage(BigDecimal.ONE)
+    ).map { (hundreds, expected) ->
+        dynamicTest("ofHundreds($hundreds) -> $expected") {
+            Percentage.ofHundreds(hundreds) shouldBe expected
+        }
+    }
+
+    @TestFactory
+    fun ofHundredsFromString() = listOf(
+        "0" to Percentage(BigDecimal.ZERO),
+        "33.333" to Percentage(BigDecimal("0.33333")),
+        "100" to Percentage(BigDecimal.ONE)
+    ).map { (hundreds, expected) ->
+        dynamicTest("ofHundreds(\"$hundreds\") -> $expected") {
+            Percentage.ofHundreds(hundreds) shouldBe expected
+        }
+    }
+
+    @TestFactory
+    fun ofFromString() = listOf(
+        "0" to Percentage(BigDecimal.ZERO),
+        "0.5" to Percentage(BigDecimal("0.5")),
+        "1" to Percentage(BigDecimal.ONE)
+    ).map { (str, expected) ->
+        dynamicTest("of(\"$str\") -> $expected") {
+            Percentage.of(str) shouldBe expected
         }
     }
 

--- a/src/test/kotlin/org/agrfesta/sh/api/domain/commons/PercentageTest.kt
+++ b/src/test/kotlin/org/agrfesta/sh/api/domain/commons/PercentageTest.kt
@@ -39,6 +39,16 @@ class PercentageTest {
     }
 
     @TestFactory
+    fun invalidOfHundredsValues() =
+        listOf(BigDecimal("-0.001"), BigDecimal("100.001"), BigDecimal("101"), BigDecimal("-1"))
+            .map {
+                dynamicTest("$it is an invalid hundreds value") {
+                    shouldThrow<IllegalArgumentException> { Percentage.ofHundreds(it) }
+                        .apply { message shouldBe "Percentage hundreds must be between 0 and 100, is $it." }
+                }
+            }
+
+    @TestFactory
     fun ofHundredsFromBigDecimal() = listOf(
         BigDecimal.ZERO to Percentage(BigDecimal.ZERO),
         BigDecimal("0.333") to Percentage(BigDecimal("0.00333")),

--- a/src/test/kotlin/org/agrfesta/sh/api/domain/commons/ThermoHygroDataTest.kt
+++ b/src/test/kotlin/org/agrfesta/sh/api/domain/commons/ThermoHygroDataTest.kt
@@ -9,13 +9,13 @@ class ThermoHygroDataTest {
 
     @TestFactory
     fun absoluteHumidityCalculations() = listOf(
-        Triple(Temperature("7.33"), RelativeHumidity("0.2333"), BigDecimal("1.84668")),
-        Triple(Temperature("40.0"), RelativeHumidity("1.0"), BigDecimal("51.18221")),
-        Triple(Temperature("34.9"), RelativeHumidity("0.759"), BigDecimal("29.90525")),
-        Triple(Temperature("10.0"), RelativeHumidity("0.5"), BigDecimal("4.69675")),
-        Triple(Temperature("30.5"), RelativeHumidity("0.001"), BigDecimal("0.03119")),
-        Triple(Temperature("18.1"), RelativeHumidity("0.99"), BigDecimal("15.29155")),
-        Triple(Temperature("0.0"), RelativeHumidity("1.0"), BigDecimal("4.84977"))
+        Triple(Temperature("7.33"), Percentage.of("0.2333"), BigDecimal("1.84668")),
+        Triple(Temperature("40.0"), Percentage.of("1.0"), BigDecimal("51.18221")),
+        Triple(Temperature("34.9"), Percentage.of("0.759"), BigDecimal("29.90525")),
+        Triple(Temperature("10.0"), Percentage.of("0.5"), BigDecimal("4.69675")),
+        Triple(Temperature("30.5"), Percentage.of("0.001"), BigDecimal("0.03119")),
+        Triple(Temperature("18.1"), Percentage.of("0.99"), BigDecimal("15.29155")),
+        Triple(Temperature("0.0"), Percentage.of("1.0"), BigDecimal("4.84977"))
     ).map {
         dynamicTest("Temp ${it.first}°C, ${it.second} -> ${it.third}g/m³") {
             ThermoHygroData(temperature = it.first, relativeHumidity = it.second)

--- a/src/test/kotlin/org/agrfesta/sh/api/providers/netatmo/NetatmoIntegrationAsserter.kt
+++ b/src/test/kotlin/org/agrfesta/sh/api/providers/netatmo/NetatmoIntegrationAsserter.kt
@@ -30,7 +30,7 @@ class NetatmoIntegrationAsserter(
         status?.apply {
             val homeStatus = aNetatmoHomeStatus(
                 rooms = listOf(aNetatmoRoomStatus(
-                    humidity = relativeHumidity.toHundreds(),
+                    humidity = relativeHumidity.value.movePointRight(2).stripTrailingZeros(),
                     measuredTemperature = temperature
                 ))
             )

--- a/src/test/kotlin/org/agrfesta/sh/api/providers/netatmo/NetatmoModelsMother.kt
+++ b/src/test/kotlin/org/agrfesta/sh/api/providers/netatmo/NetatmoModelsMother.kt
@@ -1,8 +1,8 @@
 package org.agrfesta.sh.api.providers.netatmo
 
+import java.math.BigDecimal
 import java.time.Duration
 import java.time.Instant
-import org.agrfesta.sh.api.domain.commons.RelativeHumidityHundreds
 import org.agrfesta.sh.api.domain.commons.Temperature
 import org.agrfesta.test.mothers.aRandomBoolean
 import org.agrfesta.test.mothers.aRandomHumidity
@@ -18,7 +18,7 @@ fun aNetatmoModule(
 
 fun aNetatmoRoomStatus(
     id: String = aRandomUniqueString(),
-    humidity: RelativeHumidityHundreds = aRandomHumidity().toHundreds(),
+    humidity: BigDecimal = aRandomHumidity().value.movePointRight(2).stripTrailingZeros(),
     openWindow: Boolean = aRandomBoolean(),
     measuredTemperature: Temperature = aRandomTemperature(),
     setpointTemperature: Temperature = aRandomTemperature(),

--- a/src/test/kotlin/org/agrfesta/sh/api/providers/netatmo/devices/NetatmoSmartherTest.kt
+++ b/src/test/kotlin/org/agrfesta/sh/api/providers/netatmo/devices/NetatmoSmartherTest.kt
@@ -93,7 +93,7 @@ class NetatmoSmartherTest {
             val expectedData = aRandomThermoHygroData()
             val homeStatus = aNetatmoHomeStatus(
                 rooms = listOf(aNetatmoRoomStatus(
-                    humidity = expectedData.relativeHumidity.toHundreds(),
+                    humidity = expectedData.relativeHumidity.value.movePointRight(2).stripTrailingZeros(),
                     measuredTemperature = expectedData.temperature
                 ))
             )

--- a/src/test/kotlin/org/agrfesta/sh/api/providers/switchbot/SwitchBotClientAsserter.kt
+++ b/src/test/kotlin/org/agrfesta/sh/api/providers/switchbot/SwitchBotClientAsserter.kt
@@ -14,7 +14,7 @@ class SwitchBotClientAsserter(
     fun givenSensorData(sensorProviderId: String, data: ThermoHygroData) {
         coEvery { switchBotDevicesClient.getDeviceStatus(sensorProviderId) } returns
                 mapper.aSwitchBotDeviceStatusResponse(
-                    humidity = data.relativeHumidity.toHundreds().value.toInt(),
+                    humidity = data.relativeHumidity.value.movePointRight(2).toInt(),
                     temperature = data.temperature
                 )
     }

--- a/src/test/kotlin/org/agrfesta/sh/api/schedulers/DevicesDataFetchSchedulerIntegrationTest.kt
+++ b/src/test/kotlin/org/agrfesta/sh/api/schedulers/DevicesDataFetchSchedulerIntegrationTest.kt
@@ -8,7 +8,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import org.agrfesta.sh.api.controllers.AbstractIntegrationTest
 import org.agrfesta.sh.api.domain.aDeviceDataValue
-import org.agrfesta.sh.api.domain.commons.PercentageHundreds
+import org.agrfesta.sh.api.domain.commons.Percentage
 import org.agrfesta.sh.api.domain.devices.DeviceFeature.SENSOR
 import org.agrfesta.sh.api.domain.devices.Provider
 import org.agrfesta.sh.api.persistence.jdbc.repositories.DevicesJdbcRepository
@@ -56,7 +56,7 @@ class DevicesDataFetchSchedulerIntegrationTest(
         val noSensoDevice = aDeviceDataValue(features = emptySet()).apply { devicesRepository.persist(this) }
 
         val swbSensorData = aRandomThermoHygroData(
-            relativeHumidity = PercentageHundreds(aRandomIntHumidity()).toPercentage())
+            relativeHumidity = Percentage.ofHundreds(aRandomIntHumidity()))
         val swbSensor = aDeviceDataValue(provider = Provider.SWITCHBOT, features = setOf(SENSOR))
             .apply { devicesRepository.persist(this) }
         switchBotClientAsserter.givenSensorData(swbSensor.deviceProviderId, swbSensorData)
@@ -66,7 +66,7 @@ class DevicesDataFetchSchedulerIntegrationTest(
         switchBotClientAsserter.givenSensorDataFailure(swbFaultySensor.deviceProviderId)
 
         val nttSensorData = aRandomThermoHygroData(
-            relativeHumidity = PercentageHundreds(aRandomIntHumidity()).toPercentage())
+            relativeHumidity = Percentage.ofHundreds(aRandomIntHumidity()))
         val nttSensor = aDeviceDataValue(provider = Provider.NETATMO, features = setOf(SENSOR))
             .apply { devicesRepository.persist(this) }
         netatmoIntegrationAsserter.givenDevice(nttSensor, nttSensorData)

--- a/src/test/kotlin/org/agrfesta/sh/api/schedulers/DevicesDataHistorySchedulerIntegrationTest.kt
+++ b/src/test/kotlin/org/agrfesta/sh/api/schedulers/DevicesDataHistorySchedulerIntegrationTest.kt
@@ -7,7 +7,7 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import org.agrfesta.sh.api.controllers.AbstractIntegrationTest
 import org.agrfesta.sh.api.domain.aDeviceDataValue
-import org.agrfesta.sh.api.domain.commons.PercentageHundreds
+import org.agrfesta.sh.api.domain.commons.Percentage
 import org.agrfesta.sh.api.domain.devices.DeviceFeature.SENSOR
 import org.agrfesta.sh.api.domain.devices.SensorDataType.HUMIDITY
 import org.agrfesta.sh.api.domain.devices.SensorDataType.TEMPERATURE
@@ -50,7 +50,7 @@ class DevicesDataHistorySchedulerIntegrationTest(
 
     @Test fun `historyDevicesData() saves all cached device values`() {
         val sensorData = aRandomThermoHygroData(
-            relativeHumidity = PercentageHundreds(aRandomIntHumidity()).toPercentage())
+            relativeHumidity = Percentage.ofHundreds(aRandomIntHumidity()))
 //        val sensorTemperature = aRandomTemperature()
 //        val sensorHumidity = aRandomIntHumidity()
         val sensor = aDeviceDataValue(features = setOf(SENSOR))

--- a/src/test/kotlin/org/agrfesta/sh/api/services/heating/EconomyAreasSharedHeatingStrategyTest.kt
+++ b/src/test/kotlin/org/agrfesta/sh/api/services/heating/EconomyAreasSharedHeatingStrategyTest.kt
@@ -34,7 +34,7 @@ class EconomyAreasSharedHeatingStrategyTest {
     }
     private val areas = listOf(areaB, areaC, areaA)
 
-    private val sut = EconomyAreasSharedHeatingStrategyService(percentage)
+    private val sut = EconomyAreasSharedHeatingStrategyService(percentage.value)
 
     @Test
     fun `handleHeatingFor() Do nothing when there are no areas`() {


### PR DESCRIPTION
# Refactor `Percentage` model: replace `data class` with `@JvmInline value class` and remove `PercentageHundreds`

## Context / Description

The `Percentage` domain model in `Percentage.kt` is currently implemented as two `data class` types:

- **`Percentage`** – the core domain type representing a value in `[0, 1]`
- **`PercentageHundreds`** – an adapter type representing a value in `[0, 100]`, used exclusively to convert external API values before immediately calling `.toPercentage()`

Two type aliases accompany them in `DataTypes.kt`:
```kotlin
typealias RelativeHumidity = Percentage
typealias RelativeHumidityHundreds = PercentageHundreds
```

This design has several issues that warrant a targeted refactoring.

---

## Issues Identified

### 1. `PercentageHundreds` is not a domain value — it is a pure adapter

Every usage of `PercentageHundreds` follows the same pattern:

```kotlin
PercentageHundreds(humidityInt).toPercentage()
```

It is never persisted, passed around, or used as a standalone value. Its only role is to temporarily hold a raw external integer or decimal before converting it to the domain `Percentage`. This responsibility belongs in factory methods on `Percentage` itself, not in a separate class.

### 2. `data class` is the wrong abstraction for both types

`Percentage` is a validated single-field wrapper around a `BigDecimal`. It never uses `copy()` or destructuring (`componentN`). A `data class` generates these unnecessarily. An **`@JvmInline value class`** is the correct Kotlin abstraction: it provides automatic structural `equals`/`hashCode`, avoids boxing at runtime, and signals clearly that this is a transparent, immutable wrapper.

### 3. `toString()` has an odd coupling to `PercentageHundreds`

`Percentage.toString()` currently delegates to `toHundreds().toString()`, creating a dependency on `PercentageHundreds` purely for formatting. This can be inlined directly.

### 4. `asText()` is redundant

`Percentage.asText()` is equivalent to `value.toString()`. It adds no clarity over calling `value.toString()` directly.

---

## Proposed Changes

### `Percentage.kt` — rewrite as `@JvmInline value class`

```kotlin
@JvmInline
value class Percentage(val value: BigDecimal) {
    init {
        require(value >= ZERO && value <= ONE) { "Percentage must be between 0 and 1, is $value." }
    }

    fun asText(): String = value.toString()

    override fun toString(): String {
        var hundreds = value.movePointRight(2)
        if (hundreds.scale() > 0) hundreds = hundreds.stripTrailingZeros()
        return "$hundreds%"
    }

    companion object {
        fun of(percentage: String) = Percentage(BigDecimal(percentage))
        fun ofHundreds(value: BigDecimal) = Percentage(value.movePointLeft(2).stripTrailingZeros())
        fun ofHundreds(value: Int) = ofHundreds(BigDecimal(value))
        fun ofHundreds(value: String) = ofHundreds(BigDecimal(value))
    }
}
```

- Delete `PercentageHundreds` from `Percentage.kt`
- Inline the hundreds-conversion logic into companion factory methods

### `DataTypes.kt`

- Remove the `RelativeHumidityHundreds` typealias

### Call-site updates

| File | Before | After |
|---|---|---|
| `SwitchBotModel.kt` | `PercentageHundreds(humidityInt).toPercentage()` | `Percentage.ofHundreds(humidityInt)` |
| `NetatmoModel.kt` | `humidity: RelativeHumidityHundreds` | `humidity: BigDecimal` + `Percentage.ofHundreds(humidity)` |
| `DevicesDataFetchSchedulerIntegrationTest.kt` | `PercentageHundreds(aRandomIntHumidity()).toPercentage()` | `Percentage.ofHundreds(aRandomIntHumidity())` |
| `DevicesDataHistorySchedulerIntegrationTest.kt` | same | same |
| `PercentageTest.kt` | Remove `PercentageHundreds` tests; add companion factory tests | — |

---

## Acceptance Criteria

- [ ] `data class Percentage` is replaced with `@JvmInline value class Percentage`
- [ ] `PercentageHundreds` class is deleted
- [ ] `RelativeHumidityHundreds` typealias is removed from `DataTypes.kt`
- [ ] Companion factory methods `ofHundreds(Int)`, `ofHundreds(BigDecimal)`, `ofHundreds(String)`, and `of(String)` are present on `Percentage`
- [ ] All call sites updated to use `Percentage.ofHundreds(...)` instead of `PercentageHundreds(...).toPercentage()`
- [ ] `toString()` formatting is inlined in `Percentage` with no dependency on `PercentageHundreds`
- [ ] All existing tests pass; `PercentageHundreds`-specific tests are removed or migrated
- [ ] No boxing overhead introduced (verify with `@JvmInline` semantics)